### PR TITLE
Added two papers and one Python package

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,8 @@ dianna: [https://github.com/dianna-ai/dianna](https://github.com/dianna-ai/diann
 
 Eli5: [https://github.com/TeamHG-Memex/eli5](https://github.com/TeamHG-Memex/eli5), Scikit-learn, Keras, xgboost, lightGBM, catboost etc.![](https://img.shields.io/github/stars/TeamHG-Memex/eli5.svg?style=social)
 
+explabox: [https://github.com/MarcelRobeer/explabox](https://github.com/MarcelRobeer/explabox), ONNX, Scikit-learn, Pytorch, Keras, Tensorflow, Huggingface ![](https://img.shields.io/github/stars/MarcelRobeer/explabox?style=social)
+
 explainx: [https://github.com/explainX/explainx](https://github.com/explainX/explainx), xgboost, catboost ![](https://img.shields.io/github/stars/explainX/explainx?style=social)
 
 ExplainaBoard: [https://github.com/neulab/ExplainaBoard](https://github.com/neulab/ExplainaBoard), ![](https://img.shields.io/github/stars/neulab/ExplainaBoard?style=social)

--- a/counterfactuals/README.md
+++ b/counterfactuals/README.md
@@ -97,6 +97,8 @@ Counterfactual Explanations in an Abstract Setting](https://facctconference.org/
 
 [Unsupervised Editing for Counterfactual Stories](https://arxiv.org/pdf/2112.05417.pdf), AAAI 2022
 
+CounterfactualGAN: [Generating Realistic Natural Language Counterfactuals](https://aclanthology.org/2021.findings-emnlp.306.pdf), EMNLP 2021
+
 [Getting a CLUE: A Method for Explaining Uncertainty Estimates](https://arxiv.org/abs/2006.06848), ICLR 2021
 
 [Counterfactual explanation of Bayesian model uncertainty](https://link.springer.com/article/10.1007/s00521-021-06528-z), Nerual Computing and Applications 2021
@@ -306,6 +308,8 @@ Counterfactual Explanations in an Abstract Setting](https://facctconference.org/
 [Explaining image classifiers by counterfactual generation](https://arxiv.org/pdf/1807.08024.pdf), ICLR 2019
 
 [Counterfactual Explanations without Opening the Black Box: Automated Decisions and the GDPR](https://arxiv.org/abs/1711.00399), Hardvard Journal of Law & Technology 2018 (strong recommend)
+
+[Contrastive Explanations with Local Foil Trees](https://arxiv.org/pdf/1806.07470.pdf), ICML Workshop on Human Interpretability in Machine Learning 2018
 
 [Explanations based on the Missing: Towards Contrastive Explanations with Pertinent Negatives](https://papers.nips.cc/paper/7340-explanations-based-on-the-missing-towards-contrastive-explanations-with-pertinent-negatives), NIPS 2018, [code](https://github.com/IBM/Contrastive-Explanation-Method)
 


### PR DESCRIPTION
Added two papers on counterfactuals and contrastive explanation, and soon-to-be-released Python package for explainability, fairness and robustness testing: `explabox`